### PR TITLE
Updated file name referenced

### DIFF
--- a/src/lib/components/opener/Subheadings.svelte
+++ b/src/lib/components/opener/Subheadings.svelte
@@ -16,7 +16,7 @@
 
 	const handleResumeClick = () => {
 		console.log('Clicked resume');
-		const JoshFungResume = '/JoshFungResume.pdf';
+		const JoshFungResume = '/JoshuaFungResume.pdf';
 		window.open(JoshFungResume, '_blank');
 	};
 


### PR DESCRIPTION
`Subheadings.svelte` still referenced `JoshFungResume.pdf` after the file was renamed to `JoshuaFungResume.pdf`.